### PR TITLE
Fix composer.json installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ Installation
 The Contain library and the optional mapper are both available on GitHub. Both projects are on Packagist, so if you're using Composer, just add them to your project's composer.json:
 
     "require": {
-        "akandels/contain",
-        "akandels/contain-mapper",
+        "akandels/contain": "@dev",
+        "akandels/contain-mapper": "@dev",
         ...
     }
 


### PR DESCRIPTION
You have an error in your "require" for installation.
It must reference a version.  "@dev" is the one to reference
since there is no tagged versions.
