### PR TITLE
Composer Setup Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ Installation
 The Contain library and the optional mapper are both available on GitHub. Both projects are on Packagist, so if you're using Composer, just add them to your project's composer.json:
 
     "require": {
-        "akandels/contain",
-        "akandels/contain-mapper",
+        "akandels/contain": "@dev",
+        "akandels/contain-mapper": "@dev",
         ...
     }
 

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,17 @@
         "php": ">=5.3.3",
         "zendframework/zendframework": ">=2.0.0"
     },
-    "suggest": {
-        "akandels/contain-mapper": "dev-master",
+    "require-dev": {
         "phpunit/phpunit": ">=3.7.7",
         "phpunit/php-file-iterator": ">=1.3.3",
         "phpunit/php-text-template": ">=1.1.3",
         "phpunit/php-code-coverage": ">=1.2.3",
         "phpunit/php-timer": ">=1.0.4",
         "phpunit/phpunit-mock-objects": ">=1.2.1",
-        "phpunit/php-token-stream": ">=1.1.5",
+        "phpunit/php-token-stream": ">=1.1.5"
+    },
+    "suggest": {
+        "akandels/contain-mapper": "dev-master",
         "symfony/yaml": ">=2.1.0"
     },
     "autoload": {


### PR DESCRIPTION
Fixed Installation instructions in README
Updated composer.json to remove phpunit from suggestions but require-dev

Once you actually package this and set a stable version in packagist and adjust the readme the phpunit will not suggest anything for phpunit :)
