### PR TITLE
Modified the integer type to accept a string 0 as a proper integer

### DIFF
--- a/src/Contain/Entity/Property/Type/IntegerType.php
+++ b/src/Contain/Entity/Property/Type/IntegerType.php
@@ -40,7 +40,7 @@ class IntegerType extends StringType
      */
     public function parse($value = null)
     {
-        if ($value === 0) {
+        if ($value === 0 || $value === '0') {
             return 0;
         }
 

--- a/tests/Contain/Entity/Property/Type/IntegerTypeTest.php
+++ b/tests/Contain/Entity/Property/Type/IntegerTypeTest.php
@@ -17,6 +17,7 @@ class IntegerTypeTest extends \PHPUnit_Framework_TestCase
     public function testParseZero()
     {
         $this->assertTrue(0 === $this->type->parse(0));
+        $this->assertTrue(0 === $this->type->parse('0'));
     }
 
     public function testParseEmpty()


### PR DESCRIPTION
The $value === 0 already exists but not for the string equivalent.  In order to satisfy the requirement this should be added.
