### PR TITLE
Add Aliases to Contain

### DIFF
--- a/src/Contain/Entity/AbstractEntity.php
+++ b/src/Contain/Entity/AbstractEntity.php
@@ -38,6 +38,12 @@ use Traversable;
  */
 abstract class AbstractEntity implements EntityInterface
 {
+
+    /**
+     * @var array
+     */
+    protected $aliases = array();
+
     /**
      * @var array
      */
@@ -669,7 +675,11 @@ abstract class AbstractEntity implements EntityInterface
         }
 
         if (!isset($this->properties[$name])) {
-            return false;
+            if (!isset($this->aliases[$name]) ||
+                !isset($this->properties[$this->aliases[$name]])) {
+                return false;
+            }
+            $name = $this->aliases[$name];
         }
 
         if (!$this->property) {

--- a/src/Contain/Entity/Compiler/Compiler.php
+++ b/src/Contain/Entity/Compiler/Compiler.php
@@ -341,6 +341,8 @@ class Compiler implements EventManagerAwareInterface
         $this->append('Entity/open', array(
             'namespace'    => $this->getTargetNamespace(AbstractDefinition::ENTITY),
             'name'         => $this->definition->getName(),
+            'aliases'      => $this->definition->getAliases(),
+            'allProperties' => array_merge(array_combine(array_keys($properties), array_keys($properties)), $this->definition->getAliases()),
             'constants'    => $this->definition->getConstants(),
             'properties'   => $properties,
             'implementors' => $this->definition->getImplementors(),

--- a/src/Contain/Entity/Compiler/Templates/Entity/open.template.php
+++ b/src/Contain/Entity/Compiler/Templates/Entity/open.template.php
@@ -19,6 +19,10 @@ class <?php echo $this->name; ?> extends AbstractEntity<?php
     const <?php echo strtoupper($name); ?> = <?php var_export($value); ?>;
 <?php endforeach; ?>
 
+<?php if ($this->aliases): ?>
+    protected $aliases = <?php var_export($this->aliases); ?>;
+<?php endif; ?>
+
 <?php if ($this->filter): ?>
     protected $inputFilter = '<?php echo $this->filter; ?>';
     protected $messages = array();
@@ -42,7 +46,8 @@ class <?php echo $this->name; ?> extends AbstractEntity<?php
 <?php echo $this->init; ?>
     }
 
-<?php foreach ($this->properties as $name => $property): ?>
+<?php foreach ($this->allProperties as $name => $property): ?>
+<?php $property = $this->properties[$property]; ?>
 <?php if ($property->getType() instanceof \Contain\Entity\Property\Type\ListType ||
           $property->getType() instanceof \Contain\Entity\Property\Type\HashType): ?>
     /**


### PR DESCRIPTION
Now if you have a better way of handling it certainly do it but I needed it now so I added it :)
1. There is a new option "auto_alias"
   a. If this option is set; if it sees an underscored value it will automatically create an alias that is camel cased.
2. There is a new property aliases in the AbstractEntity and the AbstractDefinition
3. The compiler needed a few quick updates that would allow to pull aliases, this worked as expected.

This way if you call $this->property('some-alias') it will return back to you the proper property.
