### PR TITLE
Export Event + Allow Extra Parameters in the Event

### DIFF
--- a/src/Contain/Entity/AbstractEntity.php
+++ b/src/Contain/Entity/AbstractEntity.php
@@ -465,6 +465,8 @@ abstract class AbstractEntity implements EntityInterface
             }
         }
 
+        $result = $this->trigger('export', $result);
+
         return $result;
     }
 

--- a/src/Contain/Event.php
+++ b/src/Contain/Event.php
@@ -129,14 +129,15 @@ class Event
      *
      * @param string $name
      * @param mixed  $value
+     * @param bool   $allowExtraParams
      *
      * @return self
      *
      * @throws  InvalidArgumentException
      */
-    public function setParam($name, $value)
+    public function setParam($name, $value, $allowExtraParams = false)
     {
-        if (!isset($this->parameters[$name])) {
+        if (!$allowExtraParams && !isset($this->parameters[$name])) {
             throw new InvalidArgumentException('"' . $name . '" is not a valid key in the parameters array');
         }
 
@@ -148,13 +149,14 @@ class Event
      * Sets parameters from a key/value array.
      *
      * @param array $params Key/value pairs
+     * @param bool  $allowExtraParams
      *
      * @return self
      */
-    public function setParams($params)
+    public function setParams($params, $allowExtraParams = false)
     {
         foreach ($params as $key => $value) {
-            $this->setParam($key, $value);
+            $this->setParam($key, $value, $allowExtraParams);
         }
 
         return $this;


### PR DESCRIPTION
## Overview

Allow for providing an export event to supply virtual properties while fetching results.  The use case here is say that you transform a value when supplying the data through an API and you want to simply adjust add a field for the end user.

For instance; I keep a numerical ID that needs to be transformed to a 16 bit 0 padded hex.  We want this to happen automatically while not supplying another result set but also do not want to clone the data thus achieving a virtual property.  While virtual properties might be a better addition later on this one seems to fit the bill.
