### PR TITLE
Numeric Strings Fail on 0

### DIFF
--- a/src/Contain/Entity/Property/Type/StringType.php
+++ b/src/Contain/Entity/Property/Type/StringType.php
@@ -51,12 +51,12 @@ class StringType implements TypeInterface
      */
     public function parse($value)
     {
-        if ($value === $this->getEmptyValue()) {
-            return $value;
+        if (is_object($value) && method_exists($value, '__toString')) {
+            $value = (string) $value;
         }
 
-        if (!$value) {
-            return $this->getUnsetValue();
+        if ($value === $this->getEmptyValue()) {
+            return $value;
         }
 
         if (is_string($value)) {
@@ -67,8 +67,8 @@ class StringType implements TypeInterface
             return (string) $value;
         }
 
-        if (is_object($value) && method_exists($value, '__toString')) {
-            return (string) $value;
+        if (!$value) {
+            return $this->getUnsetValue();
         }
 
         throw new Exception\InvalidArgumentException('$value is invalid for string type');

--- a/tests/ContainTest/Entity/Property/Type/StringTypeTest.php
+++ b/tests/ContainTest/Entity/Property/Type/StringTypeTest.php
@@ -20,7 +20,6 @@ class StringTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->type->parse(''));
         $this->assertNull($this->type->parse(false));
         $this->assertNull($this->type->parse(null));
-        $this->assertNull($this->type->parse(0));
     }
 
     public function testParseString()
@@ -30,6 +29,7 @@ class StringTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testParseNumeric()
     {
+        $this->assertEquals('0', $this->type->parse(0));
         $this->assertEquals('123', $this->type->parse(123));
         $this->assertEquals('123', $this->type->parse(123.0));
         $this->assertEquals('123', $this->type->parse((double) 123.0));
@@ -53,7 +53,6 @@ class StringTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->type->export(''));
         $this->assertEquals('', $this->type->export(false));
         $this->assertEquals('', $this->type->export(null));
-        $this->assertEquals('', $this->type->export(0));
     }
 
     public function testExportString()
@@ -63,6 +62,7 @@ class StringTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testExportNumeric()
     {
+        $this->assertEquals('0', $this->type->export(0));
         $this->assertEquals('123', $this->type->export(123));
         $this->assertEquals('123', $this->type->export(123.0));
         $this->assertEquals('123', $this->type->export((double) 123.0));


### PR DESCRIPTION
## Overview

When dealing with numbers as a string type; any number should be allowed.  This is especially important when dealing with values that can be possible in a big integer as 64 bit handling is not always available.  Due to this; a numeric value of 0 presently believes that it is an unset value.  In which case if you have big integers with a 0 based value this would then fail the condition as you are handling it as a string.

In addition to this; 0 is not an empty string but a string at a value of '0'.
## Changes
- Change processing order of strings
  - The ordering can potentially cause issues because the __toString method of an object needs to be checked against additional conditions after the value has been processed.
- Allow for a string of 0 when passing numerically as 0
