### PR TITLE
Updated as this one works for all

### DIFF
--- a/src/Contain/Entity/Compiler/Compiler.php
+++ b/src/Contain/Entity/Compiler/Compiler.php
@@ -124,19 +124,11 @@ class Compiler
             );
         }
 
-        if (preg_match('!(module|vendor|library)/([^/]+)/([^/]+)/src/(.*)!', $path, $matches)) {
-            $path = $matches[4];
-        } elseif (preg_match('!(module|vendor|library)/([^/]+)/src/(.*)!', $path, $matches)) {
-            $path = $matches[3];
-        } elseif (preg_match('!src/(.*)!', $path, $matches)) {
-            $path = $matches[1];
-        } else {
-            // attempt to determine the pathing, work in reverse
-            $search = explode('\\', get_class($this->definition));
-            $search = array_shift($search);
-            if (preg_match("!($search)/(.*)!", $path, $matches)) {
-                $path = $matches[1] . '/' . $matches[2];
-            }
+        // attempt to determine the pathing, work in reverse
+        $search = explode('\\', get_class($this->definition));
+        $search = array_shift($search);
+        if (preg_match("!.*($search)/(.*)!", $path, $matches)) {
+            $path = $matches[1] . '/' . $matches[2];
         }
 
         return str_replace('/', '\\', $path);


### PR DESCRIPTION
``` php
<?php


$paths = array(
    '/var/www/module/Digideck/src/Digideck/Entity/Definition/Foo' => 'Digideck\\Entity\\Definition\\Foo',
    '/var/www/library/Foo/Bar/Doo' => 'Foo\\Bar\\Doo',
    '/var/www/module/Foo/src/Foo/Entity/Definition/Foo' => 'Foo\\Entity\\Definition\\Foo',
);

foreach ($paths as $path => $class) {
    $search = explode('\\', $class);
    $search = array_shift($search);
    if (preg_match("!.*($search)/(.*)!", $path, $matches)) {
        var_dump($matches[1] . '/' . $matches[2]);
    }
}
```

```
string(30) "Digideck/Entity/Definition/Foo"
string(11) "Foo/Bar/Doo"
string(25) "Foo/Entity/Definition/Foo"
```
